### PR TITLE
Path and layer utils

### DIFF
--- a/Assets/_Project/Scripts/Extensions/GameObjectExtensions.cs
+++ b/Assets/_Project/Scripts/Extensions/GameObjectExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System.Linq;
 
 public static class GameObjectExtensions {
     /// <summary>

--- a/Assets/_Project/Scripts/Extensions/GameObjectExtensions.cs
+++ b/Assets/_Project/Scripts/Extensions/GameObjectExtensions.cs
@@ -72,4 +72,39 @@ public static class GameObjectExtensions {
     public static void ResetTransformation(this GameObject gameObject) {
         gameObject.transform.Reset();
     }
+    
+    /// <summary>
+    /// Returns the hierarchical path in the Unity scene hierarchy for this GameObject.
+    /// </summary>
+    /// <param name="gameObject">The GameObject to get the path for.</param>
+    /// <returns>A string representing the full hierarchical path of this GameObject in the Unity scene.
+    /// This is a '/'-separated string where each part is the name of a parent, starting from the root parent and ending
+    /// with the name of the specified GameObjects parent.</returns>
+    public static string Path(this GameObject gameObject)
+    {
+        return "/" + string.Join("/", gameObject.GetComponentsInParent<Transform>().Select(t => t.name).Reverse().ToArray());
+    }
+
+    /// <summary>
+    /// Returns the full hierarchical path in the Unity scene hierarchy for this GameObject.
+    /// </summary>
+    /// <param name="gameObject">The GameObject to get the path for.</param>
+    /// <returns>A string representing the full hierarchical path of this GameObject in the Unity scene.
+    /// This is a '/'-separated string where each part is the name of a parent, starting from the root parent and ending
+    /// with the name of the specified GameObject itself.</returns>
+    public static string PathFull(this GameObject gameObject)
+    {
+        return gameObject.Path() + "/" + gameObject.name;
+    }
+
+    /// <summary>
+    /// Recursively sets the provided layer for this GameObject and all of its descendants in the Unity scene hierarchy.
+    /// </summary>
+    /// <param name="gameObject">The GameObject to set layers for.</param>
+    /// <param name="layer">The layer number to set for GameObject and all of its descendants.</param>
+    public static void SetLayersRecursively(this GameObject gameObject, int layer)
+    {
+        gameObject.layer = layer;
+        gameObject.transform.ForEveryChild(child => child.gameObject.SetLayersRecursively(layer));
+    }
 }

--- a/Assets/_Project/Scripts/Extensions/TransformExtensions.cs
+++ b/Assets/_Project/Scripts/Extensions/TransformExtensions.cs
@@ -62,7 +62,16 @@ public static class TransformExtensions {
         parent.ForEveryChild(child => child.gameObject.SetActive(false));
     }
 
-    static void ForEveryChild(this Transform parent, System.Action<Transform> action) {
+    /// <summary>
+    /// Executes a specified action for each child of a given transform.
+    /// </summary>
+    /// <param name="parent">The parent transform.</param>
+    /// <param name="action">The action to be performed on each child.</param>
+    /// <remarks>
+    /// This method iterates over all child transforms in reverse order and executes a given action on them.
+    /// The action is a delegate that takes a Transform as parameter.
+    /// </remarks>
+    public static void ForEveryChild(this Transform parent, System.Action<Transform> action) {
         for (var i = parent.childCount - 1; i >= 0; i--) {
             action(parent.GetChild(i));
         }


### PR DESCRIPTION
I added path utils to the `GameObjectExtensions` to get a GameObjects hierarchy path and to set layers recursively. The layer setting uses the `TransformExtension.ForEveryChild` why I madde it public.