### PR TITLE
Added Random extension method

### DIFF
--- a/UnityUtils/Scripts/Extensions/EnumerableExtensions.cs
+++ b/UnityUtils/Scripts/Extensions/EnumerableExtensions.cs
@@ -1,50 +1,58 @@
 using System;
 using System.Collections.Generic;
 
-namespace UnityUtils {
-	public static class EnumerableExtensions {
-		/// <summary>
-		/// Performs an action on each element in the sequence.
-		/// </summary>
-		/// <typeparam name="T">The type of elements in the sequence.</typeparam>
-		/// <param name="sequence">The sequence to iterate over.</param>
-		/// <param name="action">The action to perform on each element.</param>    
-		public static void ForEach<T>(this IEnumerable<T> sequence, Action<T> action) {
-			foreach (var item in sequence) {
-				action(item);
-			}
-		}
+namespace UnityUtils
+{
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Performs an action on each element in the sequence.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the sequence.</typeparam>
+        /// <param name="sequence">The sequence to iterate over.</param>
+        /// <param name="action">The action to perform on each element.</param>    
+        public static void ForEach<T>(this IEnumerable<T> sequence, Action<T> action)
+        {
+            foreach (var item in sequence)
+            {
+                action(item);
+            }
+        }
 
 
-		/// <summary>
-		/// Returns a random element from the sequence.
-		/// </summary>
-		/// <typeparam name="T">The type of elements in the sequence.</typeparam>
-		/// <param name="sequence">The sequence to select the random element from.</param>
-		/// <returns>A random element from the sequence.</returns>
-		public static T Random<T>(this IEnumerable<T> sequence) {
-			if (sequence == null)
-				throw new ArgumentNullException(nameof(sequence));
+        /// <summary>
+        /// Returns a random element from the sequence.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the sequence.</typeparam>
+        /// <param name="sequence">The sequence to select the random element from.</param>
+        /// <returns>A random element from the sequence.</returns>
+        public static T Random<T>(this IEnumerable<T> sequence)
+        {
+            if (sequence == null)
+                throw new ArgumentNullException(nameof(sequence));
 
-			if (sequence is IList<T> list) {
-				if (list.Count == 0)
-					throw new InvalidOperationException("Cannot get a random element from an empty collection.");
-				return list[UnityEngine.Random.Range(0, list.Count)];
-			}
+            if (sequence is IList<T> list)
+            {
+                if (list.Count == 0)
+                    throw new InvalidOperationException("Cannot get a random element from an empty collection.");
+                return list[UnityEngine.Random.Range(0, list.Count)];
+            }
 
-			// Use reservoir sampling when the input is not an IList<T> ie: a stream or lazy sequence
-			using var enumerator = sequence.GetEnumerator();
-			if (!enumerator.MoveNext())
-				throw new InvalidOperationException("Cannot get a random element from an empty collection.");
+            // Use reservoir sampling when the input is not an IList<T> ie: a stream or lazy sequence
+            using var enumerator = sequence.GetEnumerator();
+            if (!enumerator.MoveNext())
+                throw new InvalidOperationException("Cannot get a random element from an empty collection.");
 
-			T result = enumerator.Current;
-			int count = 1;
-			while (enumerator.MoveNext()) {
-				if (UnityEngine.Random.Range(0, ++count) == 0) {
-					result = enumerator.Current;
-				}
-			}
-			return result;
-		}
-	}
+            T result = enumerator.Current;
+            int count = 1;
+            while (enumerator.MoveNext())
+            {
+                if (UnityEngine.Random.Range(0, ++count) == 0)
+                {
+                    result = enumerator.Current;
+                }
+            }
+            return result;
+        }
+    }
 }

--- a/UnityUtils/Scripts/Extensions/EnumerableExtensions.cs
+++ b/UnityUtils/Scripts/Extensions/EnumerableExtensions.cs
@@ -14,5 +14,26 @@ namespace UnityUtils {
                 action(item);
             }
         }
+
+
+        /// <summary>
+        /// Returns a random element from the sequence.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the sequence.</typeparam>
+        /// <param name="sequence">The sequence to select the random element from.</param>
+        /// <returns>A random element from the sequence.</returns>
+        public static T Random<T>(this IEnumerable<T> sequence)
+        {
+            if (sequence == null)
+                throw new ArgumentNullException(nameof(sequence));
+
+            var list = sequence as IList<T> ?? new List<T>(sequence);
+
+            if (list.Count == 0)
+                throw new InvalidOperationException("Cannot get a random element from an empty collection.");
+
+            int index = UnityEngine.Random.Range(0, list.Count);
+            return list[index];
+        }
     }
 }

--- a/UnityUtils/Scripts/Extensions/EnumerableExtensions.cs
+++ b/UnityUtils/Scripts/Extensions/EnumerableExtensions.cs
@@ -2,38 +2,49 @@ using System;
 using System.Collections.Generic;
 
 namespace UnityUtils {
-    public static class EnumerableExtensions {
-        /// <summary>
-        /// Performs an action on each element in the sequence.
-        /// </summary>
-        /// <typeparam name="T">The type of elements in the sequence.</typeparam>
-        /// <param name="sequence">The sequence to iterate over.</param>
-        /// <param name="action">The action to perform on each element.</param>    
-        public static void ForEach<T>(this IEnumerable<T> sequence, Action<T> action) {
-            foreach (var item in sequence) {
-                action(item);
-            }
-        }
+	public static class EnumerableExtensions {
+		/// <summary>
+		/// Performs an action on each element in the sequence.
+		/// </summary>
+		/// <typeparam name="T">The type of elements in the sequence.</typeparam>
+		/// <param name="sequence">The sequence to iterate over.</param>
+		/// <param name="action">The action to perform on each element.</param>    
+		public static void ForEach<T>(this IEnumerable<T> sequence, Action<T> action) {
+			foreach (var item in sequence) {
+				action(item);
+			}
+		}
 
 
-        /// <summary>
-        /// Returns a random element from the sequence.
-        /// </summary>
-        /// <typeparam name="T">The type of elements in the sequence.</typeparam>
-        /// <param name="sequence">The sequence to select the random element from.</param>
-        /// <returns>A random element from the sequence.</returns>
-        public static T Random<T>(this IEnumerable<T> sequence)
-        {
-            if (sequence == null)
-                throw new ArgumentNullException(nameof(sequence));
+		/// <summary>
+		/// Returns a random element from the sequence.
+		/// </summary>
+		/// <typeparam name="T">The type of elements in the sequence.</typeparam>
+		/// <param name="sequence">The sequence to select the random element from.</param>
+		/// <returns>A random element from the sequence.</returns>
+		public static T Random<T>(this IEnumerable<T> sequence) {
+			if (sequence == null)
+				throw new ArgumentNullException(nameof(sequence));
 
-            var list = sequence as IList<T> ?? new List<T>(sequence);
+			if (sequence is IList<T> list) {
+				if (list.Count == 0)
+					throw new InvalidOperationException("Cannot get a random element from an empty collection.");
+				return list[UnityEngine.Random.Range(0, list.Count)];
+			}
 
-            if (list.Count == 0)
-                throw new InvalidOperationException("Cannot get a random element from an empty collection.");
+			// Use reservoir sampling when the input is not an IList<T> ie: a stream or lazy sequence
+			using var enumerator = sequence.GetEnumerator();
+			if (!enumerator.MoveNext())
+				throw new InvalidOperationException("Cannot get a random element from an empty collection.");
 
-            int index = UnityEngine.Random.Range(0, list.Count);
-            return list[index];
-        }
-    }
+			T result = enumerator.Current;
+			int count = 1;
+			while (enumerator.MoveNext()) {
+				if (UnityEngine.Random.Range(0, ++count) == 0) {
+					result = enumerator.Current;
+				}
+			}
+			return result;
+		}
+	}
 }


### PR DESCRIPTION
An extension method called GetRandomElement for IEnumerable<T>. It allows for easy retrieval of a random element from any collection that implements IEnumerable<T>, including IList<T> and ICollection<T>.

Changes:
Added the Random extension method to the EnumerableExtensions class.
The method generates a random index using UnityEngine.Random.Range and returns the element at that index from the collection.
Checks are added to handle cases where the collection is null or empty, throwing appropriate exceptions (ArgumentNullException and InvalidOperationException).


Tested the method with a variety of collections, including List<T>, HashSet<T>, and arrays.